### PR TITLE
Ndv tfa

### DIFF
--- a/inferelator_ng/tests/test_tfa.py
+++ b/inferelator_ng/tests/test_tfa.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 import subprocess
 
+units_in_the_last_place_tolerance = 9 
 class TestTFA(unittest.TestCase):
 
     def generate_random_matrix(self, n, m):
@@ -11,7 +12,7 @@ class TestTFA(unittest.TestCase):
 
     # Test for 5 genes, one of which is a TF, 5 condidtions, and 4 TFs.
     # where tau is equal to 1, so exp_mat and exp_mat_tau are equivalent
-    def setup(self):
+    def setup_max(self):
         exp = pd.DataFrame(self.generate_random_matrix(5, 5))
         exp.columns = ['s1', 's2', 's3', 's4', 's5']
         exp.index = ['g1', 't2', 'g3', 'g4', 'g5']
@@ -20,26 +21,63 @@ class TestTFA(unittest.TestCase):
         priors.index = ['g1', 't2', 'g3', 'g4', 'g5']
         self.tfa_python = tfa.TFA(priors, exp, exp)
 
-    # def test_three_by_two(self):
-    #     self.setup()
-    #     activities = self.tfa_class.tfa()
-    #     print activities
+    def setup(self):
+        tau = 2
+        exp = pd.DataFrame(np.array([[1, 3], [1, 2], [0, 3]]))
+        exp.columns = ['s1', 's2']
+        exp.index = ['g1', 'tf1', 'g3']
+        priors = pd.DataFrame(np.array([[1], [1], [0]]))
+        priors.columns = ['tf1']
+        priors.index = exp.index
+        self.tfa_python = tfa.TFA(priors, exp, exp/tau)
 
-    # def test_three_by_two_dupes(self):
-    #     self.setup()
-    #     activities = self.tfa_class.tfa(dup_self = False)
-    #     print activities
+    def drop_prior(self):
+        for i in self.tfa_python.prior.columns:
+            self.tfa_python.prior = self.tfa_python.prior.drop(i, 1) 
 
-    # def test_three_by_two_self_interactions(self):
-    #     self.setup()
-    #     activities = self.tfa_class.tfa(noself = False)
-    #     print activities
+    # Test what happens when there are no relevant columns in the prior matrix
+    def test_priors_no_columns(self):
+        self.setup()
+        self.drop_prior()
+        activities = self.tfa_python.tfa()
+        # assert that there are no rows in the output activities matrix
+        self.assertEqual(activities.shape[0], 0)
 
-    # def test_three_by_two_self_interactions_and_dupes(self):
-    #     self.setup()
-    #     activities = self.tfa_class.tfa(noself = False, dup_self = False)
-    #     print activities
+    def test_priors_is_zero_vector(self):
+        self.setup()
+        self.tfa_python.prior['tf1'] = [0, 0, 0]
+        activities = self.tfa_python.tfa()
+        np.testing.assert_equal(activities.values, [[1,2]])
+        np.testing.assert_equal(self.tfa_python.prior.values, [[0], [0], [0]])
+
+    # add a duplicate TF column to the priors matrix
+    def test_duplicate_removal(self):
+        self.setup()
+        self.tfa_python.prior['g3'] = self.tfa_python.prior['tf1']
+        activities = self.tfa_python.tfa()
+        np.testing.assert_array_almost_equal_nulp(activities.values,
+            np.array([[ 0.25,   0.625], [ 0.25,   0.625]]),
+            units_in_the_last_place_tolerance)
+        # Assert the final priors matrix has no self- interactions
+        np.testing.assert_equal(self.tfa_python.prior.values, np.array([[1, 1], [0, 1], [0, 0]]))
+
+    # add a duplicate TF column to the priors matrix
+    def test_duplicate_removal_does_not_happen_with_dupes_flag_false(self):
+        self.setup()
+        self.tfa_python.prior['g3'] = self.tfa_python.prior['tf1']
+        activities = self.tfa_python.tfa(dup_self = False)
+        np.testing.assert_array_almost_equal_nulp(activities.values,
+            np.array([[ 0.25,   0.625], [ 0.25,   0.625]]),
+            units_in_the_last_place_tolerance)
+        # Assert the final priors matrix has no self- interactions
+        np.testing.assert_equal(self.tfa_python.prior.values, np.array([[1, 1], [0, 1], [0, 0]]))
+
+
     def test_tfa_default(self):
         self.setup()
-        activities = self.tfa_class.tfa()
-        print activities
+        activities = self.tfa_python.tfa()
+        np.testing.assert_array_almost_equal_nulp(activities.values,
+            np.array([[ 0.5,   1.25]]),
+            units_in_the_last_place_tolerance)
+        # Assert the final priors matrix has no self- interactions
+        np.testing.assert_equal(self.tfa_python.prior.values, np.array([[1], [0], [0]]))

--- a/inferelator_ng/tfa.py
+++ b/inferelator_ng/tfa.py
@@ -19,10 +19,6 @@ class TFA:
     exp.mat.halftau: pd.dataframe
         normalized expression matrix for time series.
 
-    no_self=True: boolean
-        If no_self (no self interaction) is True, self-regulatory interactions 
-        in prior matrix are set to 0.
-
     dup_self=True: boolean
         If dup_slef (duplicate self) is True, TFs that other TFs with the exact same 
         set of interactions in the prior are kept and will have the same activities
@@ -33,26 +29,33 @@ class TFA:
         self.exp_mat = exp_mat
         self.exp_mat_halftau = exp_mat_halftau
 
-    def tfa(self, no_self = True, dup_self = True):
+    def tfa(self, dup_self = True):
     	# tf_w_int (tf with interaction): identify TFs that have evidence of TF-gene interactions in prior matrix
+        
+        # Finds targets that have non-zero regulation
+        # TODO: Remove as some form of pre-processing???
         tf_w_int = self.prior.abs().sum(axis = 0) > 0
         tf_w_int = tf_w_int[tf_w_int].index.tolist()
 
+        # subset of prior matrix columns (TFs) that have known TF-gene interactions (tf_w_int == True)
+        prior_tf_w_int = self.prior[tf_w_int]
+
         # dup_tfs: duplicated TFs
         dup_tfs = []
-
         if dup_self:
-            # subset of prior matrix columns (TFs) that have known TF-gene interactions (tf_w_int == True)
-            prior_tf_w_int = self.prior[tf_w_int]            
+
+
+        # Everything up til now is useless if the prior is well-made.
+        # could replace with checks: check the TF list is            
             duplicates = prior_tf_w_int.transpose().duplicated(keep=False) # mark duplicates as true
             dup_tfs = duplicates[duplicates].index.tolist()
 
         # find non-duplicated TFs that are also present in target gene list 
         ndup_tfs = list(set(self.prior.columns.values.tolist()).difference(dup_tfs))
 
-        if no_self:
-            self_tfs = list(set(ndup_tfs).intersection(self.prior.index.values.tolist()))
-            self.prior.loc[self_tfs, self_tfs] = 0
+        # remove self interactions
+        self_tfs = list(set(ndup_tfs).intersection(self.prior.index.values.tolist()))
+        self.prior.loc[self_tfs, self_tfs] = 0
 
         activity = pd.DataFrame(0, index = self.prior.columns, columns = self.exp_mat_halftau.columns)
 

--- a/inferelator_ng/tfa.py
+++ b/inferelator_ng/tfa.py
@@ -37,30 +37,29 @@ class TFA:
         tf_w_int = self.prior.abs().sum(axis = 0) > 0
         tf_w_int = tf_w_int[tf_w_int].index.tolist()
 
-        # subset of prior matrix columns (TFs) that have known TF-gene interactions (tf_w_int == True)
-        prior_tf_w_int = self.prior[tf_w_int]
-
         # dup_tfs: duplicated TFs
         dup_tfs = []
         if dup_self:
 
-
         # Everything up til now is useless if the prior is well-made.
         # could replace with checks: check the TF list is            
-            duplicates = prior_tf_w_int.transpose().duplicated(keep=False) # mark duplicates as true
+            duplicates = self.prior[tf_w_int].transpose().duplicated(keep=False) # mark duplicates as true
             dup_tfs = duplicates[duplicates].index.tolist()
 
         # find non-duplicated TFs that are also present in target gene list 
         ndup_tfs = list(set(self.prior.columns.values.tolist()).difference(dup_tfs))
-
         # remove self interactions
         self_tfs = list(set(ndup_tfs).intersection(self.prior.index.values.tolist()))
-        self.prior.loc[self_tfs, self_tfs] = 0
+
+        # Set the diagonal of the self-interaction tfs to zero
+        subset = self.prior.loc[self_tfs, self_tfs].values
+        np.fill_diagonal(subset, 0)
+        self.prior.set_value(self_tfs, self_tfs, subset)
 
         activity = pd.DataFrame(0, index = self.prior.columns, columns = self.exp_mat_halftau.columns)
 
         if any(tf_w_int):
-            activity.loc[tf_w_int,:] = np.matrix(linalg.pinv2(prior_tf_w_int)) * np.matrix(self.exp_mat_halftau)
+            activity.loc[tf_w_int,:] = np.matrix(linalg.pinv2(self.prior[tf_w_int])) * np.matrix(self.exp_mat_halftau)
 
         tf_wo_int = list(set(self.prior.columns.values.tolist()).difference(tf_w_int))
         activity.loc[tf_wo_int,:] = self.exp_mat.loc[tf_wo_int,:]


### PR DESCRIPTION
@ryi06 

I've fleshed out the tests. 
As you pointed out, generating a random matrix for the test isn't a good idea since we need to check it. So now it generates a set 3x2 matrix.

2 of the tests fail, but I think that's due to real bugs: 
When trying to set the diagonal (auto-regulation_), the current code sets way too many zeros
self.prior.loc[self_tfs, self_tfs] is not the same as the diagonal unfortunately, it’s the sub-matrix

What we might want to use instead is np.fill_diagonal(priors.values, 0)
